### PR TITLE
fix memoization issue so new pages show up. Caches site map for 5 minutes instead of indefinitely

### DIFF
--- a/lib/get-site-map.ts
+++ b/lib/get-site-map.ts
@@ -21,8 +21,12 @@ export async function getSiteMap(): Promise<types.SiteMap> {
   } as types.SiteMap
 }
 
+/**
+ * Returns a memoized version of `getAllPagesImpl` that caches results for 5 minutes in stead of indefinitely.
+ * This is useful to avoid hitting the Notion API too frequently, while ensuring new content gets picked up by site.
+ */
 const getAllPages = pMemoize(getAllPagesImpl, {
-  cacheKey: (...args) => JSON.stringify(args)
+  cacheKey: (...args) => JSON.stringify([...args, Math.floor(Date.now() / (1000 * 60 * 5))]) // 5-minute cache
 })
 
 const getPage = async (pageId: string, opts?: any) => {


### PR DESCRIPTION
New pages that were sub pages from a gallery/database that was a sub-page of one of the pages were not showing. Trying this fix. May affect how often notion API is hit, but shouldn't go over limit 🤞

Trying memoization fix from claude:

"The memoization issue is in the file lib/get-site-map.ts. Looking at your uploaded code, here's the exact location:
File: lib/get-site-map.ts
Lines: Around lines 18-20
```
typescriptconst getAllPages = pMemoize(getAllPagesImpl, {
  cacheKey: (...args) => JSON.stringify(args)
})
```
This is the problematic code. The issue is that this memoization caches the results of getAllPagesImpl indefinitely, so when you add new sub-pages to Notion, they don't show up in production because the function returns the cached (stale) results instead of fetching fresh data.
To fix it, you can either:
Option 1: Temporarily disable memoization (quickest fix):
typescript// Comment out the memoized version
```
// const getAllPages = pMemoize(getAllPagesImpl, {
//   cacheKey: (...args) => JSON.stringify(args)
// })

// Use the function directly without memoization
const getAllPages = getAllPagesImpl
```
Option 2: Add time-based cache expiration:
```
typescriptconst getAllPages = pMemoize(getAllPagesImpl, {
  cacheKey: (...args) => JSON.stringify([...args, Math.floor(Date.now() / (1000 * 60 * 5))]) // 5-minute cache
})
```
The memoization was likely added for performance reasons, but it's causing your new pages to not appear because the cache never invalidates when you add new content to Notion.
Make this change in lib/get-site-map.ts, redeploy, and your recipe sub-pages should start working in production.RetryClaude does not have the ability to run the code it generates yet.E